### PR TITLE
Skipping duplicate Settings and Sections

### DIFF
--- a/SharpConfig/Configuration.Parsing.cs
+++ b/SharpConfig/Configuration.Parsing.cs
@@ -94,6 +94,11 @@ namespace SharpConfig
 
                         if (currentSection.Contains(setting.Name))
                         {
+                            if (IgnoreDuplicateSettings)
+                            {
+                                continue;
+                            }
+
                             throw new ParserException(string.Format(
                                 "The setting '{0}' was already declared in the section.",
                                 setting.Name), mLineNumber);

--- a/SharpConfig/Configuration.Parsing.cs
+++ b/SharpConfig/Configuration.Parsing.cs
@@ -65,6 +65,11 @@ namespace SharpConfig
 
                         if (config.Contains(currentSection.Name))
                         {
+                            if (IgnoreDuplicateSections)
+                            {
+                                continue;
+                            }
+
                             throw new ParserException(string.Format(
                                 "The section '{0}' was already declared in the configuration.",
                                 currentSection.Name), mLineNumber);

--- a/SharpConfig/Configuration.cs
+++ b/SharpConfig/Configuration.cs
@@ -40,6 +40,7 @@ namespace SharpConfig
             mValidCommentChars = new[] { '#', ';', '\'' };
             mIgnoreInlineComments = false;
             mIgnorePreComments = false;
+            IgnoreDuplicateSettings = false;
         }
 
         /// <summary>
@@ -553,6 +554,8 @@ namespace SharpConfig
         {
             get { return mSections.Count; }
         }
+
+        public static bool IgnoreDuplicateSettings { get; set; }
 
         /// <summary>
         /// Gets or sets a section by index.

--- a/SharpConfig/Configuration.cs
+++ b/SharpConfig/Configuration.cs
@@ -555,6 +555,10 @@ namespace SharpConfig
             get { return mSections.Count; }
         }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether duplicate
+        /// settings should be ignored when parsing a configuration.
+        /// </summary>
         public static bool IgnoreDuplicateSettings { get; set; }
 
         /// <summary>

--- a/SharpConfig/Configuration.cs
+++ b/SharpConfig/Configuration.cs
@@ -41,6 +41,7 @@ namespace SharpConfig
             mIgnoreInlineComments = false;
             mIgnorePreComments = false;
             IgnoreDuplicateSettings = false;
+            IgnoreDuplicateSettings = false;
         }
 
         /// <summary>
@@ -560,6 +561,12 @@ namespace SharpConfig
         /// settings should be ignored when parsing a configuration.
         /// </summary>
         public static bool IgnoreDuplicateSettings { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether duplicate sections
+        /// should be ignored when parsing a configuration
+        /// </summary>
+        public static bool IgnoreDuplicateSections { get; set; }
 
         /// <summary>
         /// Gets or sets a section by index.


### PR DESCRIPTION
Introduced `IgnoreDuplicateSections` and `IgnoreDuplicateSettings` to better deal with legacy configuration files, which may contain duplicate settings and/or settings. The first one will be taken, subsequent ones are skipped.