### PR TITLE
Simplified methods that take a T-instance as IN-parameter

### DIFF
--- a/SharpConfig/Section.cs
+++ b/SharpConfig/Section.cs
@@ -39,7 +39,7 @@ namespace SharpConfig
         /// <param name="name">The name of the section.</param>
         /// <param name="obj"></param>
         /// <returns>The newly created section.</returns>
-        public static Section FromObject<T>(string name, T obj)
+        public static Section FromObject(string name, object obj)
         {
             if (string.IsNullOrEmpty(name))
                 throw new ArgumentException("The section name must not be null or empty.", "name");
@@ -48,7 +48,7 @@ namespace SharpConfig
                 throw new ArgumentNullException("obj", "obj must not be null.");
 
             var section = new Section(name);
-            var type = typeof(T);
+            var type = obj.GetType();
 
             foreach (var prop in type.GetProperties(BindingFlags.Instance | BindingFlags.Public))
             {
@@ -139,12 +139,12 @@ namespace SharpConfig
         /// </summary>
         /// 
         /// <param name="obj">The object from which the values are obtained.</param>
-        public void GetValuesFrom<T>(T obj)
+        public void GetValuesFrom(object obj)
         {
             if (obj == null)
                 throw new ArgumentNullException("obj");
 
-            var type = typeof(T);
+            var type = obj.GetType();
 
             // Scan the type's properties.
             foreach (var prop in type.GetProperties(BindingFlags.Instance | BindingFlags.Public))
@@ -196,12 +196,12 @@ namespace SharpConfig
         /// </summary>
         /// 
         /// <param name="obj">The object that is modified based on the section.</param>
-        public void SetValuesTo<T>(T obj)
+        public void SetValuesTo(object obj)
         {
             if (obj == null)
                 throw new ArgumentNullException("obj");
 
-            var type = typeof(T);
+            var type = obj.GetType();
 
             // Scan the type's properties.
             foreach (var prop in type.GetProperties(BindingFlags.Instance | BindingFlags.Public))

--- a/SharpConfig/Section.cs
+++ b/SharpConfig/Section.cs
@@ -112,7 +112,30 @@ namespace SharpConfig
         /// </remarks>
         public T ToObject<T>() where T : new()
         {
-            T obj = Activator.CreateInstance<T>();
+            var type = typeof(T);
+            var obj = this.ToObject(type);
+            return obj;
+        }
+
+        /// <summary>
+        /// Creates an object of a specific type, and maps the settings
+        /// in this section to the public properties and writable fields of the object.
+        /// Properties and fields that are marked with the <see cref="IgnoreAttribute"/> attribute
+        /// or are of a type that is marked with that attribute, are ignored.
+        /// </summary>
+        /// 
+        /// <returns>The created object.</returns>
+        /// 
+        /// <remarks>
+        /// The specified type must have a public default constructor
+        /// in order to be created.
+        /// </remarks>
+        public object ToObject(Type type)
+        {
+            if (type == null)
+                throw new ArgumentNullException(nameof(type));
+
+            var obj = Activator.CreateInstance(type);
             SetValuesTo(obj);
             return obj;
         }


### PR DESCRIPTION
Imagine we have the following scenario:

```
[AttributeUsage(AttributeTargets.Property)]
public sealed class SectionNameAttribute : Attribute
{
  /// <exception cref="ArgumentNullException"><paramref name="sectionName" /> is <see langword="null" />.</exception>
  public SectionNameAttribute([NotNull] string sectionName)
  {
    if (sectionName == null)
    {
      throw new ArgumentNullException(nameof(sectionName));
    }
    this.SectionName = sectionName;
  }

  [NotNull]
  public string SectionName { get; }
}

public sealed class FooConfiguration
{
  [SectionName("Bar")]
  public Bar Bar { get; set; }
}
```

This is an abstract definition of a configuration file, which is used in a repository like:

```
var configuration = Configuration.LoadFromFile(path);

var fooConfiguration = new FooConfiguration();
foreach (var propertyInfo in typeof(FooConfiguration).GetProperties())
{
  var sectionNameAttribute = propertyInfo.GetAttributes<SectionNameAttribute>().SingleOrDefault();
  if (sectionNameAttribute != null)
  {
    var sectionName = sectionNameAttribute.SectionName;
    var section = configuration.GetSectionsNamed(sectionName).FirstOrDefault();
    if (section != null)
    {
      // verison 1:
      var mappedSection = section.ToObject<>(); // NOT WORKING, no generic type here ...
      // version 2: (would have to new the property before)
      var mappedSection = propertyInfo.GetValue(fooConfiguration, null);
      section.SetValuesTo(mappedSection); // NOT WORKING, not taking .GetType() into account
    }
  }
}
```

Therefore I've changed the behavior to take the concrete type, which is returned by `.GetType()`, into account.