### PR TITLE
Configuration setting to allow space in value without quotes enclosing them

### DIFF
--- a/SharpConfigShared/Configuration.cs
+++ b/SharpConfigShared/Configuration.cs
@@ -635,8 +635,13 @@ namespace SharpConfig
     }
 
     /// <summary>
-    /// Gets or sets a value indicating whether space is allowed
-    /// inside values without using quotes
+    /// Gets or sets a value indicating whether string values are written
+    /// without quotes, but including everything in between.
+    /// Example:
+    /// The following setting value
+    ///     MySetting=" Example value"
+    /// is written to a file in the following manner
+    ///     MySetting= Example value
     /// </summary>
     public static bool OutputRawStringValues { get; set; }
 

--- a/SharpConfigShared/Configuration.cs
+++ b/SharpConfigShared/Configuration.cs
@@ -634,6 +634,12 @@ namespace SharpConfig
     }
 
     /// <summary>
+    /// Gets or sets a value indicating whether space is allowed
+    /// inside values without using quotes
+    /// </summary>
+    public static bool SpaceInValueWithoutQuotes { get; set; }
+
+    /// <summary>
     /// Gets or sets a value indicating whether inline-comments
     /// should be ignored when parsing a configuration.
     /// </summary>

--- a/SharpConfigShared/Configuration.cs
+++ b/SharpConfigShared/Configuration.cs
@@ -71,6 +71,7 @@ namespace SharpConfig
       IgnoreInlineComments = false;
       IgnorePreComments = false;
       SpaceBetweenEquals = false;
+      OutputRawStringValues = false;
     }
 
     /// <summary>
@@ -637,7 +638,7 @@ namespace SharpConfig
     /// Gets or sets a value indicating whether space is allowed
     /// inside values without using quotes
     /// </summary>
-    public static bool SpaceInValueWithoutQuotes { get; set; }
+    public static bool OutputRawStringValues { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether inline-comments

--- a/SharpConfigShared/Setting.cs
+++ b/SharpConfigShared/Setting.cs
@@ -547,7 +547,7 @@ namespace SharpConfig
 
     private static string GetValueForOutput(string rawValue)
     {
-      if (Configuration.SpaceInValueWithoutQuotes)
+      if (Configuration.OutputRawStringValues)
         return rawValue;
 
       if (rawValue.StartsWith("{") && rawValue.EndsWith("}"))

--- a/SharpConfigShared/Setting.cs
+++ b/SharpConfigShared/Setting.cs
@@ -547,6 +547,9 @@ namespace SharpConfig
 
     private static string GetValueForOutput(string rawValue)
     {
+      if (Configuration.SpaceInValueWithoutQuotes)
+        return rawValue;
+
       if (rawValue.StartsWith("{") && rawValue.EndsWith("}"))
         return rawValue;
 


### PR DESCRIPTION
This is needed for Configuration files used by [Supervisor](http://supervisord.org/configuration.html).

For example, if I were to use this which SharpConfig currently outputs:-

```ini
[program:example]
command="/usr/bin/example --loglevel=%(ENV_LOGLEVEL)s"
```

Supervisor would not be able to find the application: **"/usr/bin/example**

So, I created a Configuration called **SpaceInValueWithoutQuotes** which is turned off by default to keep it consistent with your current API. But, when I set it to **true**, the following output is generated:-

```ini
[program:example]
command=/usr/bin/example --loglevel=%(ENV_LOGLEVEL)s
```

And this works in Supervisor.