### PR TITLE
Add Setting.GetValueOrDefault convenience method

### DIFF
--- a/SharpConfigShared/Setting.cs
+++ b/SharpConfigShared/Setting.cs
@@ -460,6 +460,32 @@ namespace SharpConfig
 
       return values;
     }
+    
+    /// <summary>
+    /// Gets this setting's value as a specific type, or a specified default value
+    /// if casting the setting to the type fails.
+    /// </summary>
+    /// <param name="def">
+    /// Default value if casting the setting to the specified type fails.
+    /// </param>
+    /// <param name="setDef">
+    /// If true, and casting the setting to the specified type fails, <paramref name="def"/> is set
+    /// as this setting's new value.
+    /// </param>
+    /// <typeparam name="T">The type of the object to retrieve.</typeparam>
+    public T GetValueOrDefault<T>(T def, bool setDef = false)
+    {
+      try
+      {
+        return GetValue<T>();
+      }
+      catch (SettingValueCastException)
+      {
+        if (setDef)
+          SetValue(def);
+        return def;
+      }
+    }
 
     // Converts the value of a single element to a desired type.
     private static object CreateObjectFromString(string value, Type dstType)


### PR DESCRIPTION
This method does the standard routine of checking if a setting is of valid type, and if not, using a default value instead, and usually also setting that default value into the configuration. This sequence takes up several lines, and for a project with loads of settings, this method really saves lines. I personally have a similar extension method always when using SharpConfig, so I'm sure it will be useful for many. Default value is not set into the configuration by default when casting to the requested type fails.

T GetValueOrDefault<T>(T def, bool setDef = false)
screen_w = setting.GetValueOrDefault(GraphicsAdapter.DefaultAdapter.CurrentDisplayMode.Width, true);
displaymode = setting.GetValueOrDefault(DisplayModes.Borderless, true);