### PR TITLE
Add Setting.GetOrDefault convenience method

### DIFF
--- a/Example/Program.cs
+++ b/Example/Program.cs
@@ -124,11 +124,13 @@ namespace Example
       var cfg = new Configuration();
 
       // Create an object.
-      var p = new SomeClass();
-      p.SomeString = "foobar";
-      p.SomeInt = 2000;
-      p.SomeInts = new[] { 1, 2, 3 };
-      p.SomeDate = DateTime.Now;
+      var p = new SomeClass
+      {
+        SomeString = "foobar",
+        SomeInt = 2000,
+        SomeInts = new[] { 1, 2, 3 },
+        SomeDate = DateTime.Now
+      };
 
       // Now create a section from it.
       cfg.Add(Section.FromObject("SomeStructure", p));

--- a/SharpConfigShared/Configuration.cs
+++ b/SharpConfigShared/Configuration.cs
@@ -266,8 +266,7 @@ namespace SharpConfig
       if (type.IsEnum)
         type = typeof(Enum);
 
-      ITypeStringConverter converter = null;
-      if (!mTypeStringConverters.TryGetValue(type, out converter))
+      if (!mTypeStringConverters.TryGetValue(type, out ITypeStringConverter converter))
         converter = mFallbackConverter;
 
       return converter;

--- a/SharpConfigShared/ITypeStringConverter.cs
+++ b/SharpConfigShared/ITypeStringConverter.cs
@@ -35,6 +35,19 @@ namespace SharpConfig
     /// The type that this converter is able to convert to and from a string.
     /// </summary>
     Type ConvertibleType { get; }
+
+    /// <summary>
+    /// Tries to convert a string value to an object of this converter's type.
+    /// </summary>
+    /// <param name="value"></param>
+    /// <param name="hint">
+    ///     A type hint. This is used rarely, such as in the enum converter.
+    ///     The enum converter's official type is Enum, whereas the type hint
+    ///     represents the underlying enum type.
+    ///     This parameter can be safely ignored for custom converters.
+    /// </param>
+    /// <returns>The converted object, or null if conversion is not possible.</returns>
+    object TryConvertFromString(string value, Type hint);
   }
 
   /// <summary>
@@ -68,5 +81,18 @@ namespace SharpConfig
     /// The type that this converter is able to convert to and from a string.
     /// </summary>
     public Type ConvertibleType => typeof(T);
+
+    /// <summary>
+    /// Tries to convert a string value to an object of this converter's type.
+    /// </summary>
+    /// <param name="value"></param>
+    /// <param name="hint">
+    ///     A type hint. This is used rarely, such as in the enum converter.
+    ///     The enum converter's official type is Enum, whereas the type hint
+    ///     represents the underlying enum type.
+    ///     This parameter can be safely ignored for custom converters.
+    /// </param>
+    /// <returns>The converted object, or null if conversion is not possible.</returns>
+    public abstract object TryConvertFromString(string value, Type hint);
   }
 }

--- a/SharpConfigShared/Section.cs
+++ b/SharpConfigShared/Section.cs
@@ -291,13 +291,11 @@ namespace SharpConfig
       }
       else
       {
-        var prop = member as PropertyInfo;
-        if (prop != null)
-          return prop.PropertyType.GetCustomAttributes(typeof(IgnoreAttribute), false).Length > 0;
+        if (member as PropertyInfo != null)
+          return (member as PropertyInfo).PropertyType.GetCustomAttributes(typeof(IgnoreAttribute), false).Length > 0;
 
-        var field = member as FieldInfo;
-        if (field != null)
-          return field.FieldType.GetCustomAttributes(typeof(IgnoreAttribute), false).Length > 0;
+        if (member as FieldInfo != null)
+          return (member as FieldInfo).FieldType.GetCustomAttributes(typeof(IgnoreAttribute), false).Length > 0;
       }
 
       return false;

--- a/SharpConfigShared/Setting.cs
+++ b/SharpConfigShared/Setting.cs
@@ -462,7 +462,7 @@ namespace SharpConfig
     }
 
     // Converts the value of a single element to a desired type.
-    private static object CreateObjectFromString(string value, Type dstType)
+    private static object CreateObjectFromString(string value, Type dstType, bool tryConvert = false)
     {
       var underlyingType = Nullable.GetUnderlyingType(dstType);
       if (underlyingType != null)
@@ -477,6 +477,11 @@ namespace SharpConfig
 
       var converter = Configuration.FindTypeStringConverter(dstType);
 
+      if (tryConvert)
+      {
+        return converter.TryConvertFromString(value, dstType);
+      }
+      
       try
       {
         return converter.ConvertFromString(value, dstType);

--- a/SharpConfigShared/Setting.cs
+++ b/SharpConfigShared/Setting.cs
@@ -572,7 +572,7 @@ namespace SharpConfig
     private void SetEmptyValue()
     {
       mRawValue = string.Empty;
-      mCachedArraySize = 0;
+      mCachedArraySize = -1;
       mShouldCalculateArraySize = false;
     }
 

--- a/SharpConfigShared/Setting.cs
+++ b/SharpConfigShared/Setting.cs
@@ -460,33 +460,38 @@ namespace SharpConfig
 
       return values;
     }
-    
+
     /// <summary>
     /// Gets this setting's value as a specific type, or a specified default value
     /// if casting the setting to the type fails.
     /// </summary>
-    /// <param name="def">
+    /// <param name="defaultValue">
     /// Default value if casting the setting to the specified type fails.
     /// </param>
-    /// <param name="setDef">
-    /// If true, and casting the setting to the specified type fails, <paramref name="def"/> is set
+    /// <param name="setDefault">
+    /// If true, and casting the setting to the specified type fails, <paramref name="defaultValue"/> is set
     /// as this setting's new value.
     /// </param>
     /// <typeparam name="T">The type of the object to retrieve.</typeparam>
-    public T GetOrDefault<T>(T def, bool setDef = false)
+    public T GetValueOrDefault<T>(T defaultValue, bool setDefault = false)
     {
       var type = typeof(T);
-      
-      if (type.IsArray)
-        throw new InvalidOperationException("GetOrDefault<T> cannot be used with arrays.");
 
-      if (this.IsArray)
+      if (type.IsArray)
+        throw new InvalidOperationException("GetValueOrDefault<T> cannot be used with arrays.");
+
+      if (IsArray)
         throw new InvalidOperationException("The setting represents an array. Use GetValueArray() to obtain its value.");
 
       var result = CreateObjectFromString(mRawValue, type, true);
-      if (result != null) return (T)result;
-      if (setDef) SetValue(def);
-      return def;
+
+      if (result != null)
+        return (T)result;
+
+      if (setDefault)
+        SetValue(defaultValue);
+
+      return defaultValue;
     }
 
     // Converts the value of a single element to a desired type.
@@ -509,7 +514,7 @@ namespace SharpConfig
       {
         return converter.TryConvertFromString(value, dstType);
       }
-      
+
       try
       {
         return converter.ConvertFromString(value, dstType);

--- a/SharpConfigShared/Setting.cs
+++ b/SharpConfigShared/Setting.cs
@@ -460,6 +460,34 @@ namespace SharpConfig
 
       return values;
     }
+    
+    /// <summary>
+    /// Gets this setting's value as a specific type, or a specified default value
+    /// if casting the setting to the type fails.
+    /// </summary>
+    /// <param name="def">
+    /// Default value if casting the setting to the specified type fails.
+    /// </param>
+    /// <param name="setDef">
+    /// If true, and casting the setting to the specified type fails, <paramref name="def"/> is set
+    /// as this setting's new value.
+    /// </param>
+    /// <typeparam name="T">The type of the object to retrieve.</typeparam>
+    public T GetOrDefault<T>(T def, bool setDef = false)
+    {
+      var type = typeof(T);
+      
+      if (type.IsArray)
+        throw new InvalidOperationException("GetOrDefault<T> cannot be used with arrays.");
+
+      if (this.IsArray)
+        throw new InvalidOperationException("The setting represents an array. Use GetValueArray() to obtain its value.");
+
+      var result = CreateObjectFromString(mRawValue, type, true);
+      if (result != null) return (T)result;
+      if (setDef) SetValue(def);
+      return def;
+    }
 
     // Converts the value of a single element to a desired type.
     private static object CreateObjectFromString(string value, Type dstType, bool tryConvert = false)

--- a/Tests/CustomConverterTest.cs
+++ b/Tests/CustomConverterTest.cs
@@ -33,6 +33,20 @@ namespace Tests
 
       return person;
     }
+
+    // This method attempts to convert the value to a Person object.
+    // It is used instead when Setting.GetOrDefault<T> is called.
+    public override object TryConvertFromString(string value, Type hint)
+    {
+      try
+      {
+        return ConvertFromString(value, hint);
+      }
+      catch
+      {
+        return null;
+      }
+    }
   }
 
   [TestFixture]

--- a/Tests/SimpleConfigTest.cs
+++ b/Tests/SimpleConfigTest.cs
@@ -314,7 +314,7 @@ namespace Tests
       AssertArraysAreEqual(new[] { "{123}", "456" }, section["Setting12"].StringValueArray);
 
       Assert.IsTrue(section["Setting13"].IsArray);
-      AssertArraysAreEqual(new[] { "first\"\"second", "\"\"third fourth\"\"", "fifth" }, section["Setting13"].StringValueArray);
+      AssertArraysAreEqual(new[] { "first\"\"second", "third fourth", "fifth" }, section["Setting13"].StringValueArray);
     }
 
     sealed class SectionTestObject

--- a/Tests/SimpleConfigTest.cs
+++ b/Tests/SimpleConfigTest.cs
@@ -555,6 +555,183 @@ namespace Tests
       });
     }
 
+    [Test]
+    public void GetOrDefault()
+    {
+      var cfg = new Configuration();
+      var setting = cfg["Section"]["Setting"];
+      
+      /* Test all the converters with valid and invalid values:
+       * bool, byte, char, datetime, decimal, double, enum, int16, int32,
+       * int64, sbyte, single, uint16, uint32, uint64
+       * Use explicit type argument specification in all cases even though
+       * it is not always necessary. */
+
+      #region Bool
+      
+      setting.BoolValue = true; // valid value
+      Assert.AreEqual(setting.GetOrDefault<bool>(false), true);
+      setting.SetValue("invalid value"); // invalid value
+      Assert.AreEqual(setting.GetOrDefault<bool>(false), false);
+      setting.GetOrDefault<bool>(false, true); // test setDef
+      Assert.AreEqual(setting.BoolValue, false);
+      
+      #endregion
+      #region Byte
+      
+      setting.ByteValue = 100; // valid value
+      Assert.AreEqual(setting.GetOrDefault<byte>(200), 100);
+      setting.SetValue("invalid value"); // invalid value
+      Assert.AreEqual(setting.GetOrDefault<byte>(200), 200);
+      setting.GetOrDefault<byte>(200, true); // test setDef
+      Assert.AreEqual(setting.ByteValue, 200);
+      
+      #endregion
+      #region Char
+      
+      setting.CharValue = 'c'; // valid value
+      Assert.AreEqual(setting.GetOrDefault<char>('f'), 'c');
+      setting.SetValue("invalid value"); // invalid value
+      Assert.AreEqual(setting.GetOrDefault<char>('f'), 'f');
+      setting.GetOrDefault<char>('f', true); // test setDef
+      Assert.AreEqual(setting.CharValue, 'f');
+      
+      #endregion
+      #region DateTime
+      
+      // Some problems with DateTime.ToString omitting milliseconds when DateTime.Now was used as test value.
+      setting.DateTimeValue = DateTime.Today; // valid value
+      Assert.AreEqual(setting.GetOrDefault<DateTime>(DateTime.MinValue), DateTime.Today);
+      setting.SetValue("invalid value"); // invalid value
+      Assert.AreEqual(setting.GetOrDefault<DateTime>(DateTime.MinValue), DateTime.MinValue);
+      setting.GetOrDefault<DateTime>(DateTime.MinValue, true); // test setDef
+      Assert.AreEqual(setting.DateTimeValue, DateTime.MinValue);
+      
+      #endregion
+      #region Decimal
+      
+      setting.DecimalValue = 2004.40493028m; // valid value
+      Assert.AreEqual(setting.GetOrDefault<decimal>(1000.2028m), 2004.40493028m);
+      setting.SetValue("invalid value"); // invalid value
+      Assert.AreEqual(setting.GetOrDefault<decimal>(1000.2028m), 1000.2028m);
+      setting.GetOrDefault<decimal>(1000.2028m, true); // test setDef
+      Assert.AreEqual(setting.DecimalValue, 1000.2028m);
+      
+      #endregion
+      #region Double
+      
+      setting.DoubleValue = 404.404; // valid value
+      Assert.AreEqual(setting.GetOrDefault<double>(123.456), 404.404);
+      setting.SetValue("invalid value"); // invalid value
+      Assert.AreEqual(setting.GetOrDefault<double>(123.456), 123.456);
+      setting.GetOrDefault<double>(123.456, true); // test setDef
+      Assert.AreEqual(setting.DoubleValue, 123.456);
+      
+      #endregion
+      #region Enum
+
+      // Chose a random enum
+      setting.SetValue(GCNotificationStatus.NotApplicable); // valid value
+      Assert.AreEqual(setting.GetOrDefault<GCNotificationStatus>(GCNotificationStatus.Succeeded), GCNotificationStatus.NotApplicable);
+      setting.SetValue("invalid value"); // invalid value
+      Assert.AreEqual(setting.GetOrDefault<GCNotificationStatus>(GCNotificationStatus.Succeeded), GCNotificationStatus.Succeeded);
+      setting.GetOrDefault<GCNotificationStatus>(GCNotificationStatus.Succeeded, true); // test setDef
+      Assert.AreEqual(setting.GetValue(typeof(GCNotificationStatus)), GCNotificationStatus.Succeeded);
+      
+      #endregion
+      #region Int16
+
+      setting.SetValue((short)123); // valid value
+      Assert.AreEqual(setting.GetOrDefault<short>(456), 123);
+      setting.SetValue("invalid value"); // invalid value
+      Assert.AreEqual(setting.GetOrDefault<short>(456), 456);
+      setting.GetOrDefault<short>(456, true); // test setDef
+      Assert.AreEqual(setting.GetValue(typeof(short)), 456);
+      
+      #endregion
+      #region Int32
+
+      setting.IntValue = 4567; // valid value
+      Assert.AreEqual(setting.GetOrDefault<int>(1010), 4567);
+      setting.SetValue("invalid value"); // invalid value
+      Assert.AreEqual(setting.GetOrDefault<int>(1010), 1010);
+      setting.GetOrDefault<int>(1010, true); // test setDef
+      Assert.AreEqual(setting.IntValue, 1010);
+      
+      #endregion
+      #region Int64
+
+      setting.SetValue((long)75467456); // valid value
+      Assert.AreEqual(setting.GetOrDefault<long>(14623146), 75467456);
+      setting.SetValue("invalid value"); // invalid value
+      Assert.AreEqual(setting.GetOrDefault<long>(14623146), 14623146);
+      setting.GetOrDefault<long>(14623146, true); // test setDef
+      Assert.AreEqual(setting.GetValue(typeof(long)), 14623146);
+      
+      #endregion
+      #region SByte
+
+      setting.SByteValue = 123; // valid value
+      Assert.AreEqual(setting.GetOrDefault<sbyte>(-123), 123);
+      setting.SetValue("invalid value"); // invalid value
+      Assert.AreEqual(setting.GetOrDefault<sbyte>(-123), -123);
+      setting.GetOrDefault<sbyte>(-123, true); // test setDef
+      Assert.AreEqual(setting.SByteValue, -123);
+      
+      #endregion
+      #region Single
+
+      setting.FloatValue = 123.456f; // valid value
+      Assert.AreEqual(setting.GetOrDefault<float>(-456.123f), 123.456f);
+      setting.SetValue("invalid value"); // invalid value
+      Assert.AreEqual(setting.GetOrDefault<float>(-456.123f), -456.123f);
+      setting.GetOrDefault<float>(-456.123f, true); // test setDef
+      Assert.AreEqual(setting.FloatValue, -456.123f);
+      
+      #endregion
+      #region String
+
+      // Test that double quotation marks are trimmed properly
+      setting.StringValue = "\"string\"";
+      Assert.AreEqual(setting.GetOrDefault<string>("default"), "string");
+      setting.StringValue = "\"\"\"Triple quotes\"\"\"";
+      Assert.AreEqual(setting.GetOrDefault<string>("default"), "Triple quotes");
+      setting.GetOrDefault<string>("\"\"\"Triple quotes\"\"\"", true); // test setDef
+      Assert.AreEqual(setting.StringValue, "Triple quotes");
+      
+      #endregion
+      #region UInt16
+
+      setting.SetValue((ushort)1000); // valid value
+      Assert.AreEqual(setting.GetOrDefault<ushort>(2000), 1000);
+      setting.SetValue("invalid value"); // invalid value
+      Assert.AreEqual(setting.GetOrDefault<ushort>(2000), 2000);
+      setting.GetOrDefault<ushort>(2000, true); // test setDef
+      Assert.AreEqual(setting.GetValue(typeof(ushort)), 2000);
+      
+      #endregion
+      #region UInt32
+
+      setting.SetValue((uint)12345); // valid value
+      Assert.AreEqual(setting.GetOrDefault<uint>(54321), 12345);
+      setting.SetValue("invalid value"); // invalid value
+      Assert.AreEqual(setting.GetOrDefault<uint>(54321), 54321);
+      setting.GetOrDefault<uint>(54321, true); // test setDef
+      Assert.AreEqual(setting.GetValue(typeof(uint)), 54321);
+      
+      #endregion
+      #region UInt64
+
+      setting.SetValue((ulong)1234567); // valid value
+      Assert.AreEqual(setting.GetOrDefault<ulong>(7654321), 1234567);
+      setting.SetValue("invalid value"); // invalid value
+      Assert.AreEqual(setting.GetOrDefault<ulong>(7654321), 7654321);
+      setting.GetOrDefault<ulong>(7654321, true); // test setDef
+      Assert.AreEqual(setting.GetValue(typeof(ulong)), 7654321);
+      
+      #endregion
+    }
+
     private static void TestWithFile(Configuration cfg, Action<string> action)
     {
       var filename = Path.GetTempFileName();

--- a/Tests/SimpleConfigTest.cs
+++ b/Tests/SimpleConfigTest.cs
@@ -556,7 +556,7 @@ namespace Tests
     }
 
     [Test]
-    public void GetOrDefault()
+    public void GetValueOrDefault()
     {
       var cfg = new Configuration();
       var setting = cfg["Section"]["Setting"];
@@ -570,30 +570,30 @@ namespace Tests
       #region Bool
       
       setting.BoolValue = true; // valid value
-      Assert.AreEqual(setting.GetOrDefault<bool>(false), true);
+      Assert.AreEqual(setting.GetValueOrDefault<bool>(false), true);
       setting.SetValue("invalid value"); // invalid value
-      Assert.AreEqual(setting.GetOrDefault<bool>(false), false);
-      setting.GetOrDefault<bool>(false, true); // test setDef
+      Assert.AreEqual(setting.GetValueOrDefault<bool>(false), false);
+      setting.GetValueOrDefault<bool>(false, true); // test setDef
       Assert.AreEqual(setting.BoolValue, false);
       
       #endregion
       #region Byte
       
       setting.ByteValue = 100; // valid value
-      Assert.AreEqual(setting.GetOrDefault<byte>(200), 100);
+      Assert.AreEqual(setting.GetValueOrDefault<byte>(200), 100);
       setting.SetValue("invalid value"); // invalid value
-      Assert.AreEqual(setting.GetOrDefault<byte>(200), 200);
-      setting.GetOrDefault<byte>(200, true); // test setDef
+      Assert.AreEqual(setting.GetValueOrDefault<byte>(200), 200);
+      setting.GetValueOrDefault<byte>(200, true); // test setDef
       Assert.AreEqual(setting.ByteValue, 200);
       
       #endregion
       #region Char
       
       setting.CharValue = 'c'; // valid value
-      Assert.AreEqual(setting.GetOrDefault<char>('f'), 'c');
+      Assert.AreEqual(setting.GetValueOrDefault<char>('f'), 'c');
       setting.SetValue("invalid value"); // invalid value
-      Assert.AreEqual(setting.GetOrDefault<char>('f'), 'f');
-      setting.GetOrDefault<char>('f', true); // test setDef
+      Assert.AreEqual(setting.GetValueOrDefault<char>('f'), 'f');
+      setting.GetValueOrDefault<char>('f', true); // test setDef
       Assert.AreEqual(setting.CharValue, 'f');
       
       #endregion
@@ -601,30 +601,30 @@ namespace Tests
       
       // Some problems with DateTime.ToString omitting milliseconds when DateTime.Now was used as test value.
       setting.DateTimeValue = DateTime.Today; // valid value
-      Assert.AreEqual(setting.GetOrDefault<DateTime>(DateTime.MinValue), DateTime.Today);
+      Assert.AreEqual(setting.GetValueOrDefault<DateTime>(DateTime.MinValue), DateTime.Today);
       setting.SetValue("invalid value"); // invalid value
-      Assert.AreEqual(setting.GetOrDefault<DateTime>(DateTime.MinValue), DateTime.MinValue);
-      setting.GetOrDefault<DateTime>(DateTime.MinValue, true); // test setDef
+      Assert.AreEqual(setting.GetValueOrDefault<DateTime>(DateTime.MinValue), DateTime.MinValue);
+      setting.GetValueOrDefault<DateTime>(DateTime.MinValue, true); // test setDef
       Assert.AreEqual(setting.DateTimeValue, DateTime.MinValue);
       
       #endregion
       #region Decimal
       
       setting.DecimalValue = 2004.40493028m; // valid value
-      Assert.AreEqual(setting.GetOrDefault<decimal>(1000.2028m), 2004.40493028m);
+      Assert.AreEqual(setting.GetValueOrDefault<decimal>(1000.2028m), 2004.40493028m);
       setting.SetValue("invalid value"); // invalid value
-      Assert.AreEqual(setting.GetOrDefault<decimal>(1000.2028m), 1000.2028m);
-      setting.GetOrDefault<decimal>(1000.2028m, true); // test setDef
+      Assert.AreEqual(setting.GetValueOrDefault<decimal>(1000.2028m), 1000.2028m);
+      setting.GetValueOrDefault<decimal>(1000.2028m, true); // test setDef
       Assert.AreEqual(setting.DecimalValue, 1000.2028m);
       
       #endregion
       #region Double
       
       setting.DoubleValue = 404.404; // valid value
-      Assert.AreEqual(setting.GetOrDefault<double>(123.456), 404.404);
+      Assert.AreEqual(setting.GetValueOrDefault<double>(123.456), 404.404);
       setting.SetValue("invalid value"); // invalid value
-      Assert.AreEqual(setting.GetOrDefault<double>(123.456), 123.456);
-      setting.GetOrDefault<double>(123.456, true); // test setDef
+      Assert.AreEqual(setting.GetValueOrDefault<double>(123.456), 123.456);
+      setting.GetValueOrDefault<double>(123.456, true); // test setDef
       Assert.AreEqual(setting.DoubleValue, 123.456);
       
       #endregion
@@ -632,60 +632,60 @@ namespace Tests
 
       // Chose a random enum
       setting.SetValue(GCNotificationStatus.NotApplicable); // valid value
-      Assert.AreEqual(setting.GetOrDefault<GCNotificationStatus>(GCNotificationStatus.Succeeded), GCNotificationStatus.NotApplicable);
+      Assert.AreEqual(setting.GetValueOrDefault<GCNotificationStatus>(GCNotificationStatus.Succeeded), GCNotificationStatus.NotApplicable);
       setting.SetValue("invalid value"); // invalid value
-      Assert.AreEqual(setting.GetOrDefault<GCNotificationStatus>(GCNotificationStatus.Succeeded), GCNotificationStatus.Succeeded);
-      setting.GetOrDefault<GCNotificationStatus>(GCNotificationStatus.Succeeded, true); // test setDef
+      Assert.AreEqual(setting.GetValueOrDefault<GCNotificationStatus>(GCNotificationStatus.Succeeded), GCNotificationStatus.Succeeded);
+      setting.GetValueOrDefault<GCNotificationStatus>(GCNotificationStatus.Succeeded, true); // test setDef
       Assert.AreEqual(setting.GetValue(typeof(GCNotificationStatus)), GCNotificationStatus.Succeeded);
       
       #endregion
       #region Int16
 
       setting.SetValue((short)123); // valid value
-      Assert.AreEqual(setting.GetOrDefault<short>(456), 123);
+      Assert.AreEqual(setting.GetValueOrDefault<short>(456), 123);
       setting.SetValue("invalid value"); // invalid value
-      Assert.AreEqual(setting.GetOrDefault<short>(456), 456);
-      setting.GetOrDefault<short>(456, true); // test setDef
+      Assert.AreEqual(setting.GetValueOrDefault<short>(456), 456);
+      setting.GetValueOrDefault<short>(456, true); // test setDef
       Assert.AreEqual(setting.GetValue(typeof(short)), 456);
       
       #endregion
       #region Int32
 
       setting.IntValue = 4567; // valid value
-      Assert.AreEqual(setting.GetOrDefault<int>(1010), 4567);
+      Assert.AreEqual(setting.GetValueOrDefault<int>(1010), 4567);
       setting.SetValue("invalid value"); // invalid value
-      Assert.AreEqual(setting.GetOrDefault<int>(1010), 1010);
-      setting.GetOrDefault<int>(1010, true); // test setDef
+      Assert.AreEqual(setting.GetValueOrDefault<int>(1010), 1010);
+      setting.GetValueOrDefault<int>(1010, true); // test setDef
       Assert.AreEqual(setting.IntValue, 1010);
       
       #endregion
       #region Int64
 
       setting.SetValue((long)75467456); // valid value
-      Assert.AreEqual(setting.GetOrDefault<long>(14623146), 75467456);
+      Assert.AreEqual(setting.GetValueOrDefault<long>(14623146), 75467456);
       setting.SetValue("invalid value"); // invalid value
-      Assert.AreEqual(setting.GetOrDefault<long>(14623146), 14623146);
-      setting.GetOrDefault<long>(14623146, true); // test setDef
+      Assert.AreEqual(setting.GetValueOrDefault<long>(14623146), 14623146);
+      setting.GetValueOrDefault<long>(14623146, true); // test setDef
       Assert.AreEqual(setting.GetValue(typeof(long)), 14623146);
       
       #endregion
       #region SByte
 
       setting.SByteValue = 123; // valid value
-      Assert.AreEqual(setting.GetOrDefault<sbyte>(-123), 123);
+      Assert.AreEqual(setting.GetValueOrDefault<sbyte>(-123), 123);
       setting.SetValue("invalid value"); // invalid value
-      Assert.AreEqual(setting.GetOrDefault<sbyte>(-123), -123);
-      setting.GetOrDefault<sbyte>(-123, true); // test setDef
+      Assert.AreEqual(setting.GetValueOrDefault<sbyte>(-123), -123);
+      setting.GetValueOrDefault<sbyte>(-123, true); // test setDef
       Assert.AreEqual(setting.SByteValue, -123);
       
       #endregion
       #region Single
 
       setting.FloatValue = 123.456f; // valid value
-      Assert.AreEqual(setting.GetOrDefault<float>(-456.123f), 123.456f);
+      Assert.AreEqual(setting.GetValueOrDefault<float>(-456.123f), 123.456f);
       setting.SetValue("invalid value"); // invalid value
-      Assert.AreEqual(setting.GetOrDefault<float>(-456.123f), -456.123f);
-      setting.GetOrDefault<float>(-456.123f, true); // test setDef
+      Assert.AreEqual(setting.GetValueOrDefault<float>(-456.123f), -456.123f);
+      setting.GetValueOrDefault<float>(-456.123f, true); // test setDef
       Assert.AreEqual(setting.FloatValue, -456.123f);
       
       #endregion
@@ -693,40 +693,40 @@ namespace Tests
 
       // Test that double quotation marks are trimmed properly
       setting.StringValue = "\"string\"";
-      Assert.AreEqual(setting.GetOrDefault<string>("default"), "string");
+      Assert.AreEqual(setting.GetValueOrDefault<string>("default"), "string");
       setting.StringValue = "\"\"\"Triple quotes\"\"\"";
-      Assert.AreEqual(setting.GetOrDefault<string>("default"), "Triple quotes");
-      setting.GetOrDefault<string>("\"\"\"Triple quotes\"\"\"", true); // test setDef
+      Assert.AreEqual(setting.GetValueOrDefault<string>("default"), "Triple quotes");
+      setting.GetValueOrDefault<string>("\"\"\"Triple quotes\"\"\"", true); // test setDef
       Assert.AreEqual(setting.StringValue, "Triple quotes");
       
       #endregion
       #region UInt16
 
       setting.SetValue((ushort)1000); // valid value
-      Assert.AreEqual(setting.GetOrDefault<ushort>(2000), 1000);
+      Assert.AreEqual(setting.GetValueOrDefault<ushort>(2000), 1000);
       setting.SetValue("invalid value"); // invalid value
-      Assert.AreEqual(setting.GetOrDefault<ushort>(2000), 2000);
-      setting.GetOrDefault<ushort>(2000, true); // test setDef
+      Assert.AreEqual(setting.GetValueOrDefault<ushort>(2000), 2000);
+      setting.GetValueOrDefault<ushort>(2000, true); // test setDef
       Assert.AreEqual(setting.GetValue(typeof(ushort)), 2000);
       
       #endregion
       #region UInt32
 
       setting.SetValue((uint)12345); // valid value
-      Assert.AreEqual(setting.GetOrDefault<uint>(54321), 12345);
+      Assert.AreEqual(setting.GetValueOrDefault<uint>(54321), 12345);
       setting.SetValue("invalid value"); // invalid value
-      Assert.AreEqual(setting.GetOrDefault<uint>(54321), 54321);
-      setting.GetOrDefault<uint>(54321, true); // test setDef
+      Assert.AreEqual(setting.GetValueOrDefault<uint>(54321), 54321);
+      setting.GetValueOrDefault<uint>(54321, true); // test setDef
       Assert.AreEqual(setting.GetValue(typeof(uint)), 54321);
       
       #endregion
       #region UInt64
 
       setting.SetValue((ulong)1234567); // valid value
-      Assert.AreEqual(setting.GetOrDefault<ulong>(7654321), 1234567);
+      Assert.AreEqual(setting.GetValueOrDefault<ulong>(7654321), 1234567);
       setting.SetValue("invalid value"); // invalid value
-      Assert.AreEqual(setting.GetOrDefault<ulong>(7654321), 7654321);
-      setting.GetOrDefault<ulong>(7654321, true); // test setDef
+      Assert.AreEqual(setting.GetValueOrDefault<ulong>(7654321), 7654321);
+      setting.GetValueOrDefault<ulong>(7654321, true); // test setDef
       Assert.AreEqual(setting.GetValue(typeof(ulong)), 7654321);
       
       #endregion


### PR DESCRIPTION
Let's try this again. Previous PR used a try-catch block and was inefficient as @lijian4607 pointed out.

**`T GetOrDefault<T>(T def, bool setDef = false)`**

This method does the standard routine of checking if a setting is of valid type, and if not, using a default value instead, and usually also setting that default value as the settings' new value. This convenience method saves a lot of time in a project with a lot of settings.

This implementation adds `TryConvertFromString(string, Type)` method to `ITypeStringConverter`, as an alternative to `ConvertFromString(string, Type)`.

`TryConvertFromString(string, Type)` attempts to parse the value using methods specific to the type like `int.TryParse` and returns the result, or null if parsing fails.

Added a new optional parameter for `Setting.CreateObjectFromString` (bool tryConvert = false). If true, `TryConvertFromString` is used instead of `ConvertFromString`, and result returned as is.

`GetOrDefault` calls `CreateObjectFromString` with tryConvert = true. If the result is not null, it is returned. If result is null, the specified default value is returned. Optionally, default value is set as the new value for the setting if setDef = true.

`TryConvertFromString(string, Type)` can also be used in future for other features/cleaning.

This is one way of implementing this, and I hope it works better this time. Also added unit tests for the stock converters. Let me know what you think. =)

```
T GetOrDefault(T def, bool setDef = false)
screen_w = setting.GetOrDefault(GraphicsAdapter.DefaultAdapter.CurrentDisplayMode.Width, true);
displaymode = setting.GetOrDefault(DisplayModes.Borderless, true);
```