### PR TITLE
Properly parse a line to find a comment

### DIFF
--- a/Src/ConfigurationReader.cs
+++ b/Src/ConfigurationReader.cs
@@ -130,10 +130,7 @@ namespace SharpConfig
       {
         // The end of the string has not been reached => index points to a valid comment character.
         commentCharIndex = index;
-
-        // If it's not the last character, extract the comment.
-        if (line.Length > index + 1)
-          comment = line.Substring(index + 1).TrimStart();
+        comment = line.Substring(index + 1).TrimStart();
       }
 
       return comment;

--- a/Tests/SimpleConfigTest.cs
+++ b/Tests/SimpleConfigTest.cs
@@ -213,7 +213,10 @@ namespace Tests
           "## ###" + Environment.NewLine +
           ";Line4" + Environment.NewLine +
           "[Section2]" + Environment.NewLine +
-          "Setting=\"Val;#ue\"# InlineComment3";
+          "Setting=\"Val;#ue\"# InlineComment3" + Environment.NewLine +
+          "ValidUglySetting1 = \"this is # not a comment\" # this is a comment \"with a quote\" inside" + Environment.NewLine +
+          "ValidUglySetting2 = this is \\# not a comment # this is a comment" + Environment.NewLine +
+          "ValidUglySetting3 = { first, \"second # still, second\" } # comment \"with a quote\" and a closing brace }";
 
       var cfg = Configuration.LoadFromString(cfgStr);
 
@@ -240,6 +243,9 @@ namespace Tests
       Assert.IsTrue(cfg.Contains("Section2"));
       Assert.IsTrue(cfg.Contains("Section", "Setting"));
       Assert.IsTrue(cfg.Contains("Section2", "Setting"));
+      Assert.IsTrue(cfg.Contains("Section2", "ValidUglySetting1"));
+      Assert.IsTrue(cfg.Contains("Section2", "ValidUglySetting2"));
+      Assert.IsTrue(cfg.Contains("Section2", "ValidUglySetting3"));
 
       var section = cfg["Section"];
       var section2 = cfg["Section2"];
@@ -268,9 +274,19 @@ namespace Tests
 
       Assert.IsNull(section2.Comment);
       Assert.AreEqual("InlineComment3", section2["Setting"].Comment);
+      Assert.AreEqual("this is a comment \"with a quote\" inside", section2["ValidUglySetting1"].Comment);
+      Assert.AreEqual("this is a comment", section2["ValidUglySetting2"].Comment);
+      Assert.AreEqual("comment \"with a quote\" and a closing brace }", section2["ValidUglySetting3"].Comment);
 
       Assert.AreEqual("Value", section["Setting"].StringValue);
       Assert.AreEqual("Val;#ue", section2["Setting"].StringValue);
+      Assert.AreEqual("this is # not a comment", section2["ValidUglySetting1"].StringValue);
+      Assert.AreEqual("this is \\# not a comment", section2["ValidUglySetting2"].StringValue);
+      Assert.IsTrue(section2["ValidUglySetting3"].IsArray);
+      Assert.AreEqual(2, section2["ValidUglySetting3"].ArraySize);
+      Assert.AreEqual("first", section2["ValidUglySetting3"].StringValueArray[0]);
+      Assert.AreEqual("second # still, second", section2["ValidUglySetting3"].StringValueArray[1]);
+      
     }
 
     [Test]


### PR DESCRIPTION
Fixes #102.

Parse each line from beginning to end until you find the first valid comment character that:
1. is not within a quote (eg. `"this is # not a comment"`), **and**
2. is not escaped (eg. `this is \# not a comment either`).

A quote has two quotation marks, neither of which is escaped.
For example: `"this is a quote \" with an escaped quotation mark inside of it"`

Remove `IsInQuoteMarks` (yay!)