### PR TITLE
[Regression] Fix for preserving quotes - part 1

### DIFF
--- a/Src/StockStringConverters.cs
+++ b/Src/StockStringConverters.cs
@@ -324,10 +324,10 @@ namespace SharpConfig
   internal sealed class StringStringConverter : TypeStringConverter<string>
   {
     public override string ConvertToString(object value)
-      => value.ToString().Trim('\"');
+      => Configuration.OutputRawStringValues ? value.ToString() : value.ToString().Trim('\"');
 
     public override object TryConvertFromString(string value, Type hint)
-      => value.Trim('\"');
+      => Configuration.OutputRawStringValues ? value : value.Trim('\"');
   }
 
   internal sealed class UInt16StringConverter : TypeStringConverter<ushort>


### PR DESCRIPTION
@cemdervis 

When using RawStringValues the value of the string should not change in any manner including preserving any quotes present at the beginning or ending of the string

I came across this problem when I updated my libraries to the latest version and found that quotes in my string not being preserved and new ones being introduced. Setting OutputRawStringValues does not fix the issue without this patch to actually preserve the raw string values.