### PR TITLE
[Regression] Fix for preserving quotes - part 2

### DIFF
--- a/Src/Setting.cs
+++ b/Src/Setting.cs
@@ -72,8 +72,8 @@ namespace SharpConfig
     /// </summary>
     public string StringValue
     {
-      get => GetValue<string>().Trim('\"');
-      set => SetValue(value.Trim('\"'));
+      get => Configuration.OutputRawStringValues ? GetValue<string>() : GetValue<string>().Trim('\"');
+      set => SetValue(Configuration.OutputRawStringValues ? value : value.Trim('\"'));
     }
 
     /// <summary>


### PR DESCRIPTION
@cemdervis 

When using RawStringValues the value of the string should not change in any manner including preserving any quotes present at the beginning or ending of the string

I'm adding this a separate patch since while this issue could be worked around by changing all references in the code to use `RawValue` instead to `StringValue`, however it will break existing projects as they will need to rewrite their code. Instead the clean and appropriate way should be to account for `OutputRawStringValues` so that the library such that preserves the behavior of the original library and projects need not have to rewrite their code other than simply setting `OutputRawStringValues`. This would enable a clean way to upgrade the library to the latest versions.

This caused quite some grief for us while upgrading because there are a lot of references in our project to `StringValue`, which the original library was returning as a RawStringValue. This patch will improve upgrade compatibility.