### PR TITLE
[Regression BUG] Handle IgnoreInlineComments correctly

### DIFF
--- a/Src/ConfigurationReader.cs
+++ b/Src/ConfigurationReader.cs
@@ -58,7 +58,7 @@ namespace SharpConfig
         }
 
         string lineWithoutComment = line;
-        if (commentIndex > 0)
+        if (!Configuration.IgnoreInlineComments && commentIndex > 0)
         {
           lineWithoutComment = line.Remove(commentIndex).Trim(); // remove inline comment
         }


### PR DESCRIPTION
Regression bug that was introduced after code refactoring, check if IgnoreInlineComments is enabled and if so then don't process any inline comments otherwise it will fail and throw and error when processing inline comments in a section header

E.g. this combination of settings will throw and error with the current code

INI Configuration:
`Configuration.IgnoreInlineComments = true`

INI Section Header
`[A:\ServerFolders\On Patrol Live - WE448 - #157.ptr]`

This check was present in the original code and then removed leading to improper handling of inline section comments